### PR TITLE
feat: add prefill option to development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ cp .env.example .env.local
 npm run dev
 ```
 
+### Development Features
+
+#### Quick Form Fill Mode
+
+When developing locally, you can use a keyboard shortcut to automatically fill forms with test data:
+
+- Windows/Linux: `Alt + P`
+- Mac: `Command (⌘) + P`
+
+This feature:
+- Only works in development mode
+- Pre-fills all form fields with sample data
+- Helps speed up testing and development
+- Can be triggered at any point in the form flow
+
+The test data includes:
+- Platform selection
+- Content information
+- Reporting details
+- Follow-up responses
+
 ## Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details and read our [Code of Conduct](CODE_OF_CONDUCT.md).
@@ -87,4 +108,4 @@ Support our mission further by [sponsoring us on GitHub](https://github.com/spon
 
 This project uses the [MIT License](/LICENSE). While the core tech stack included here is open-source, some external integrations used in this project require subscriptions.
 
-All of Chayn's projects are open-source. 
+All of Chayn's projects are open-source.

--- a/lib/dev/prefill.ts
+++ b/lib/dev/prefill.ts
@@ -1,0 +1,53 @@
+import { IS_DEVELOPMENT } from '../constants/common';
+
+// Sample data for quick testing
+export const PREFILL_DATA = {
+  platformInfo: {
+    platformId: 'facebook',
+    platformName: 'Facebook',
+    isCustom: false
+  },
+  reportingInfo: {
+    status: 'both-completed' as const
+  },
+  initialQuestions: {
+    contentLocationType: 'url' as const,
+    contentUrl: 'https://facebook.com/test-content-123',
+    contentType: 'intimate' as const,
+    contentContext: 'hacked' as const,
+    imageUploadDate: '15 March 2024',
+    imageTakenDate: '1 March 2024',
+    ownershipEvidence: 'I can verify this content through specific identifiable features and original files.',
+    impactStatement: 'This has caused significant distress and affected my personal and professional life.'
+  },
+  reportingDetails: {
+    standardProcessDetails: 'I reported through the standard process on March 16th using the report button.',
+    escalatedProcessDetails: 'I submitted an escalated report through the help center on March 18th.',
+    responseReceived: 'I received an automated response but no further action was taken.',
+    additionalStepsTaken: 'I followed up via email on March 20th requesting an update.'
+  },
+  followUpData: {
+    questions: [],
+    answers: {
+      'additional-context': 'The content was taken from my compromised cloud storage account.',
+      'previous-contact': 'I have email records of all previous correspondence.',
+      'specific-violations': 'The content violates privacy policies and terms regarding non-consensual sharing.'
+    }
+  }
+};
+
+export function usePrefillData() {
+  if (!IS_DEVELOPMENT) return null;
+
+  const handleKeyPress = (event: KeyboardEvent) => {
+    // Support both Alt + P (Windows/Linux) and Command + P (Mac)
+    if ((event.altKey || event.metaKey) && event.key.toLowerCase() === 'p') {
+      // Prevent the browser's print dialog on Mac
+      event.preventDefault();
+      return PREFILL_DATA;
+    }
+    return null;
+  };
+
+  return handleKeyPress;
+}


### PR DESCRIPTION
This pull request introduces a new "Quick Form Fill Mode" feature for development, which allows developers to pre-fill forms with test data using a keyboard shortcut. The changes include updates to documentation, the addition of a utility for pre-filling data, and integration of this feature into the form context. Below are the most important changes:

### Documentation Updates
* Added a "Development Features" section in `README.md` to describe the "Quick Form Fill Mode," including instructions for triggering the feature and details of the test data it provides.

### Feature Implementation
* Created a new utility in `lib/dev/prefill.ts` that defines sample test data (`PREFILL_DATA`) and a function (`usePrefillData`) to handle keyboard shortcuts (`Alt + P` or `Command + P`) for pre-filling forms.
* Integrated the pre-fill functionality into the `FormProvider` component in `lib/context/FormContext.tsx`. This includes adding a `useEffect` hook to listen for the keyboard shortcut and update the form state with the test data.

### Development Environment Check
* Updated `lib/context/FormContext.tsx` to import and use the `IS_DEVELOPMENT` constant, ensuring that the pre-fill functionality is only available in development mode.