### PR TITLE
Improve contentUrl validation

### DIFF
--- a/app/letter-generator/components/initial-questions.tsx
+++ b/app/letter-generator/components/initial-questions.tsx
@@ -9,6 +9,7 @@ import { analytics } from '@/lib/analytics';
 import { GA_EVENTS } from '@/lib/constants/analytics';
 import { useFormContext } from '@/lib/context/FormContext';
 import { clientConfig } from '@/lib/rollbar';
+import { isValidUrl, normalizeUrl } from '@/lib/utils';
 import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
@@ -195,6 +196,12 @@ export function InitialQuestions({ onComplete }: InitialQuestionsProps) {
   const handleFormSubmit = (data: InitialQuestionsForm) => {
     try {
       analytics.trackEvent(GA_EVENTS.TDLG_INITIAL_QUESTIONS_CONTINUE_CLICKED);
+      
+      // Normalize URL if URL type is selected
+      if (data.contentLocationType === 'url' && data.contentUrl) {
+        data.contentUrl = normalizeUrl(data.contentUrl);
+      }
+
       const timeSpent = Math.floor((Date.now() - startTime) / 1000);
       analytics.trackInitialQuestionsCompleted(timeSpent);
 
@@ -319,15 +326,14 @@ export function InitialQuestions({ onComplete }: InitialQuestionsProps) {
                 <div className="space-y-2">
                   <Input
                     id="contentUrl"  
-                    type="url"
+                    type="text"
                     {...register('contentUrl', {
                       required: 'Please provide the URL where the content can be found',
-                      pattern: {
-                        value: /^https?:\/\/.+/i,
-                        message: 'Please enter a valid URL starting with http:// or https://'
+                      validate: {
+                        isValidUrl: (value) => isValidUrl(value||'') || 'Please enter a valid URL'
                       }
                     })}
-                    placeholder="https://example.com/content"
+                    placeholder="facebook.com/content or https://www.facebook.com/content"
                     className="bg-white focus:ring-accent focus:border-accent"
                   />
                   {errors.contentUrl && (

--- a/cypress/e2e/platforms/facebook.cy.ts
+++ b/cypress/e2e/platforms/facebook.cy.ts
@@ -20,7 +20,7 @@ function selectFacebookContentTypeAndContext() {
 
 function fillFacebookContentLocationAndDates() {
   cy.get('input[type="radio"][value="url"]').check();
-  cy.get('input[type="url"]').type('https://facebook.com/harmful-post-123');
+  cy.get('input[id="contentUrl"]').type('https://facebook.com/harmful-post-123');
   cy.get('#imageUploadDate').type('1 March 2025');
   cy.get('#imageTakenDate').type('15 February 2025');
   cy.log('Filled Facebook content location and dates');

--- a/cypress/e2e/platforms/instagram.cy.ts
+++ b/cypress/e2e/platforms/instagram.cy.ts
@@ -19,7 +19,7 @@ function selectInstagramContentTypeAndContext() {
 
 function fillInstagramContentLocationAndDates() {
   cy.get('input[type="radio"][value="url"]').check();
-  cy.get('input[type="url"]').type('https://instagram.com/harmful-post-123');
+  cy.get('input[id="contentUrl"]').type('https://instagram.com/harmful-post-123');
   cy.get('#imageUploadDate').type('1 March 2025');
   cy.get('#imageTakenDate').type('15 February 2025');
   cy.log('Filled Instagram content location and dates');

--- a/cypress/e2e/platforms/onlyfans.cy.ts
+++ b/cypress/e2e/platforms/onlyfans.cy.ts
@@ -17,7 +17,7 @@ function selectContentTypeAndContext() {
 
 function fillContentLocationAndDates() {
   cy.get('input[type="radio"][value="url"]').check();
-  cy.get('input[type="url"]').type('https://onlyfans.com/harmful-post-123');
+  cy.get('input[id="contentUrl"]').type('https://onlyfans.com/harmful-post-123');
   cy.get('#imageUploadDate').type('1 March 2025');
   cy.get('#imageTakenDate').type('15 February 2025');
 }

--- a/cypress/e2e/platforms/other.cy.ts
+++ b/cypress/e2e/platforms/other.cy.ts
@@ -16,7 +16,7 @@ describe('Other Platform Flow', () => {
     cy.contains('Account was compromised').click();
 
     cy.get('input[type="radio"][value="url"]').check();
-    cy.get('input[type="url"]').type('https://reddit.com/harmful-post-123');
+    cy.get('input[id="contentUrl"]').type('https://reddit.com/harmful-post-123');
     cy.get('#imageUploadDate').type('1 March 2025');
     cy.get('#imageTakenDate').type('15 February 2025');
 

--- a/cypress/e2e/platforms/pornhub.cy.ts
+++ b/cypress/e2e/platforms/pornhub.cy.ts
@@ -17,7 +17,7 @@ describe('Pornhub Platform Flow', () => {
     cy.contains('Account was compromised').click();
 
     cy.get('input[type="radio"][value="url"]').check();
-    cy.get('input[type="url"]').type('https://pornhub.com/harmful-post-123');
+    cy.get('input[id="contentUrl"]').type('https://pornhub.com/harmful-post-123');
     cy.get('#imageUploadDate').type('1 March 2025');
     cy.get('#imageTakenDate').type('15 February 2025');
 

--- a/cypress/e2e/platforms/tiktok.cy.ts
+++ b/cypress/e2e/platforms/tiktok.cy.ts
@@ -15,7 +15,7 @@ describe('Tiktok Platform Flow', () => {
     cy.contains('Account was compromised').click();
 
     cy.get('input[type="radio"][value="url"]').check();
-    cy.get('input[type="url"]').type('https://tiktok.com/harmful-post-123');
+    cy.get('input[id="contentUrl"]').type('https://tiktok.com/harmful-post-123');
     cy.get('#imageUploadDate').type('1 March 2025');
     cy.get('#imageTakenDate').type('15 February 2025');
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -63,3 +63,44 @@ export function parseAIJson(input: string) {
     throw error instanceof Error ? error : new Error('Failed to parse response as JSON');
   }
 }
+
+export function normalizeUrl(url: string): string {
+  try {
+    // If the URL doesn't start with a protocol, add https://
+    if (!url.match(/^https?:\/\//i)) {
+      url = 'https://' + url;
+    }
+
+    // Add www. if it's missing and the domain is a known platform
+    const knownPlatforms = ['facebook.com', 'instagram.com', 'tiktok.com', 'onlyfans.com'];
+    const urlObj = new URL(url);
+    const domain = urlObj.hostname.replace(/^www\./i, '');
+    
+    if (knownPlatforms.includes(domain) && !urlObj.hostname.startsWith('www.')) {
+      urlObj.hostname = 'www.' + urlObj.hostname;
+    }
+
+    return urlObj.toString();
+  } catch (error) {
+    // If URL parsing fails, return the original string
+    // The form validation will catch invalid URLs
+    return url;
+  }
+}
+
+export function isValidUrl(url: string): boolean {
+  try {
+    const urlObj = new URL(normalizeUrl(url));
+    // Check for valid protocol
+    if (!urlObj.protocol.match(/^https?:$/i)) {
+      return false;
+    }
+    // Check for valid hostname
+    if (!urlObj.hostname.match(/^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/i)) {
+      return false;
+    }
+    return true;
+  } catch (error) {
+    return false;
+  }
+}


### PR DESCRIPTION
Allow `contentUrl` field to be flexible to accept and normalise e.g.:
[facebook.com/123](http://facebook.com/123)

[www.facebook.com/123](http://www.facebook.com/123)

https://facebook.com/123

https://www.facebook.com/123

http://facebook.com/123

http://www.facebook.com/123