### PR TITLE
Add zapier webhooks for follow up and quality check prompts

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,34 +1,16 @@
 import { handleApiError, serverInstance as rollbar } from '@/lib/rollbar';
+import { sendToZapier } from '@/lib/zapier';
 import { NextResponse } from 'next/server';
 
 export async function POST(request: Request) {
   rollbar.info('feedback: Received feedback submission');
   try {
-    if (!process.env.NEXT_PUBLIC_ZAPIER_WEBHOOK_URL) {
+    if (!process.env.NEXT_PUBLIC_ZAPIER_FEEDBACK_WEBHOOK_URL) {
       return NextResponse.json({ error: 'Zapier webhook URL not configured' }, { status: 500 });
     }
 
     const body = await request.json();
-
-    const response = await fetch(process.env.NEXT_PUBLIC_ZAPIER_WEBHOOK_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      rollbar.error('feedback: Failed to submit feedback to Zapier');
-      throw new Error('Failed to submit feedback to Zapier');
-    }
-    rollbar.info('feedback: Successfully submitted feedback to Zapier', {
-      status: response.status,
-      body: JSON.stringify(body),
-    });
+    await sendToZapier(process.env.NEXT_PUBLIC_ZAPIER_FEEDBACK_WEBHOOK_URL, body);
 
     return NextResponse.json({ success: true });
   } catch (error: any) {

--- a/lib/prompts/quality-check.ts
+++ b/lib/prompts/quality-check.ts
@@ -135,7 +135,8 @@ You must respond with a valid JSON object containing exactly these fields:
   "issues": [
     {
       "type": "critical" | "minor",
-      "issue": "A precise description of the specific issue found, ideally referencing the instruction number or a clear example. For banned terms, state the term found. For policy issues, state the policy that was incorrectly referenced or missed."
+      "issue": "A precise description of the specific issue found. For banned terms, state the term found. For policy issues, state the policy that was incorrectly referenced or missed.",
+      "issueType: "The type of issue: hallucination, sensitive data, policy error, banned term, tone/style, structure/clarity, evidence/information, or subject line quality. Do not include specific examples of the issue, just the type.",
     }
   ],
   "improvedLetter": {

--- a/lib/rollbar.ts
+++ b/lib/rollbar.ts
@@ -9,6 +9,7 @@ const baseConfig = {
   captureUnhandledRejections: true,
   environment: ENVIRONMENT,
   captureIP: 'anonymize',
+  scrubTelemetryInputs: true,
   enabled: !!clientToken,
   payload: {
     environment: ENVIRONMENT,

--- a/lib/zapier.ts
+++ b/lib/zapier.ts
@@ -1,0 +1,37 @@
+import { serverInstance as rollbar } from './rollbar';
+
+export async function sendToZapier(webhookUrl: string, payload: Record<string, any>) {
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      rollbar.error('Failed to submit data to Zapier', {
+        status: response.status,
+        payload: JSON.stringify(payload),
+      });
+      throw new Error('Failed to submit data to Zapier');
+    }
+
+    rollbar.info('Successfully submitted data to Zapier', {
+      status: response.status,
+      payload: JSON.stringify(payload),
+    });
+
+    return response;
+  } catch (error) {
+    rollbar.error('Error sending data to Zapier', {
+      error,
+      payload: JSON.stringify(payload),
+    });
+    throw error;
+  }
+}


### PR DESCRIPTION
### What changes did you make and why did you make them?
This PR adds functionality to send the follow up questions responses, and any failed quality check responses, 

Note `// if (qualityCheckResult.severity === 'critical' && process.env.NEXT_PUBLIC_ZAPIER_QUALITY_WEBHOOK_URL) {` should be uncommented on following PR but is required to setup zapier webhook for now