### PR TITLE
Fix volunteer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Chayn is proudly open-source and built with volunteer contributions. We are grat
 
 **Please consider giving this repository a star ⭐ and follow our GitHub profile to help us grow our open-source community and find more contributors like you!**
 
-Support our mission further by [sponsoring us on GitHub](https://github.com/sponsors/chaynHQ), exploring [our volunteer programs](https://www.chayn.co/volunteer), and following us on [social media](https://linktr.ee/chayn).
+Support our mission further by [sponsoring us on GitHub](https://github.com/sponsors/chaynHQ), exploring [our volunteer programs](https://www.chayn.co/get-involved), and following us on [social media](https://linktr.ee/chayn).
 
 ## License
 


### PR DESCRIPTION
### Resolves no existing issue.

### What changes did you make and why did you make them?

The URL in the README was leading to a 404 so I want to replace https://www.chayn.co/volunteer with https://www.chayn.co/get-involved.

### Did you run tests? Please share screenshots:
Not needed.

### How did you find us? (GitHub, Google search, social media, hackathon, etc.):
Social Media.

<!--- PR CHECKLIST: —>
Before submitting, check that you have completed the following tasks:
- [ ] Answered the questions above.
- [ ] Enabled "Allow edits and access to secrets by maintainers" on this PR.
- [ ] If applicable, include images in the description.
After submitting, please be available for discussion. Thank you!
