### PR TITLE
Keyboard & screen-reader support for the letter-generator flow

### DIFF
--- a/app/letter-generator/components/error-message.tsx
+++ b/app/letter-generator/components/error-message.tsx
@@ -8,9 +8,9 @@ interface ErrorMessageProps {
 
 export function ErrorMessage({ message, onRetry }: ErrorMessageProps) {
   return (
-    <div className="flex flex-col items-center justify-center py-8 sm:py-12">
+    <div role="alert" className="flex flex-col items-center justify-center py-8 sm:py-12">
       <div className="bg-destructive/10 rounded-xl p-6 max-w-xl text-center">
-        <AlertCircle className="w-8 h-8 mx-auto mb-4 text-destructive" />
+        <AlertCircle className="w-8 h-8 mx-auto mb-4 text-destructive" aria-hidden="true" />
         <h3 className="text-lg font-medium mb-2">Letter generation failed</h3>
         <p className="text-muted-foreground mb-6">{message || 'There was an issue generating your letter. Please try again.'}</p>
         <Button 

--- a/app/letter-generator/components/follow-up-questions.tsx
+++ b/app/letter-generator/components/follow-up-questions.tsx
@@ -269,9 +269,9 @@ export function FollowUpQuestions({
 
   if (isLoading) {
     return (
-      <div className="flex flex-col items-center justify-center py-12">
+      <div role="status" className="flex flex-col items-center justify-center py-12">
         <div className="bg-accent-light/50 rounded-xl p-6 max-w-xl text-center">
-          <Loader2 className="w-8 h-8 mx-auto mb-4 animate-spin text-primary" />
+          <Loader2 className="w-8 h-8 mx-auto mb-4 animate-spin text-primary" aria-hidden="true" />
           <h3 className="text-lg font-medium mb-2">Analysing your responses</h3>
           <p className="text-muted-foreground">
             We&apos;re using AI to analyse your responses and generate relevant supporting questions to
@@ -284,9 +284,9 @@ export function FollowUpQuestions({
 
   if (error && followUpQuestions.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-12">
+      <div role="alert" className="flex flex-col items-center justify-center py-12">
         <div className="bg-accent-light/50 rounded-xl p-6 max-w-xl text-center">
-          <AlertCircle className="w-8 h-8 mx-auto mb-4 text-primary" />
+          <AlertCircle className="w-8 h-8 mx-auto mb-4 text-primary" aria-hidden="true" />
           <h3 className="text-lg font-medium mb-2">Unable to generate supporting questions</h3>
           <p className="text-muted-foreground mb-6">
             We&apos;re having trouble connecting to our AI service. You can proceed with generating your
@@ -305,7 +305,7 @@ export function FollowUpQuestions({
 
   if (!isLoading && followUpQuestions.length === 0 && !error && hasInitialized) {
     return (
-      <div className="flex flex-col items-center justify-center py-12">
+      <div role="status" className="flex flex-col items-center justify-center py-12">
         <div className="bg-accent-light/50 rounded-xl p-6 max-w-xl text-center">
           <h3 className="text-lg font-medium mb-2">No additional questions needed</h3>
           <p className="text-muted-foreground mb-6">

--- a/app/letter-generator/components/initial-questions.tsx
+++ b/app/letter-generator/components/initial-questions.tsx
@@ -21,6 +21,7 @@ import 'regenerator-runtime/runtime';
 import { QuestionSection } from './question-section';
 import { SelectableCard } from './selectable-card';
 import { VoiceInput } from './voice-input';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 
 interface InitialQuestionsForm {
   contentLocationType: 'url' | 'description';
@@ -253,28 +254,31 @@ export function InitialQuestions({ onComplete }: InitialQuestionsProps) {
         >
           <div className="space-y-8">
             <div className="space-y-3">
-              <Label className="text-lg font-medium">What type of content was shared?*</Label>
-              <div className="grid grid-cols-2 gap-3 mt-4">
-                <Controller
-                  name="contentType"
-                  control={control}
-                  rules={{ required: true }}
-                  render={({ field }) => (
-                    <>
-                      {contentTypes.map((type) => (
-                        <SelectableCard
-                          key={type.value}
-                          value={type.value}
-                          label={type.label}
-                          description={type.description}
-                          selected={field.value === type.value}
-                          onClick={() => field.onChange(type.value)}
-                        />
-                      ))}
-                    </>
-                  )}
-                />
-              </div>
+              <p id="content-type-label" className="text-lg font-medium">
+                What type of content was shared?*
+              </p>
+              <Controller
+                name="contentType"
+                control={control}
+                rules={{ required: true }}
+                render={({ field }) => (
+                  <RadioGroupPrimitive.Root
+                    value={field.value || ''}
+                    onValueChange={field.onChange}
+                    aria-labelledby="content-type-label"
+                    className="grid grid-cols-2 gap-3 mt-4"
+                  >
+                    {contentTypes.map((type) => (
+                      <SelectableCard
+                        key={type.value}
+                        value={type.value}
+                        label={type.label}
+                        description={type.description}
+                      />
+                    ))}
+                  </RadioGroupPrimitive.Root>
+                )}
+              />
               {errors.contentType && (
                 <p className="text-sm text-destructive">
                   Knowing the type of content helps us identify which platform policies have been
@@ -284,28 +288,31 @@ export function InitialQuestions({ onComplete }: InitialQuestionsProps) {
             </div>
 
             <div className="space-y-3">
-              <Label className="text-lg font-medium">How was the content shared?*</Label>
-              <div className="grid grid-cols-2 gap-3 mt-4">
-                <Controller
-                  name="contentContext"
-                  control={control}
-                  rules={{ required: true }}
-                  render={({ field }) => (
-                    <>
-                      {contentContexts.map((context) => (
-                        <SelectableCard
-                          key={context.value}
-                          value={context.value}
-                          label={context.label}
-                          description={context.description}
-                          selected={field.value === context.value}
-                          onClick={() => field.onChange(context.value)}
-                        />
-                      ))}
-                    </>
-                  )}
-                />
-              </div>
+              <p id="content-context-label" className="text-lg font-medium">
+                How was the content shared?*
+              </p>
+              <Controller
+                name="contentContext"
+                control={control}
+                rules={{ required: true }}
+                render={({ field }) => (
+                  <RadioGroupPrimitive.Root
+                    value={field.value || ''}
+                    onValueChange={field.onChange}
+                    aria-labelledby="content-context-label"
+                    className="grid grid-cols-2 gap-3 mt-4"
+                  >
+                    {contentContexts.map((context) => (
+                      <SelectableCard
+                        key={context.value}
+                        value={context.value}
+                        label={context.label}
+                        description={context.description}
+                      />
+                    ))}
+                  </RadioGroupPrimitive.Root>
+                )}
+              />
               {errors.contentContext && (
                 <p className="text-sm text-destructive">
                   Understanding how the content was shared helps us address specific privacy
@@ -315,9 +322,11 @@ export function InitialQuestions({ onComplete }: InitialQuestionsProps) {
             </div>
 
             <div className="space-y-4">
-              <Label className="text-lg font-medium">Where can the content be found?*</Label>
+              <p id="content-location-label" className="text-lg font-medium">
+                Where can the content be found?*
+              </p>
               <div className="space-y-4 mt-4">
-                <div className="flex gap-4">
+                <div className="flex gap-4" role="radiogroup" aria-labelledby="content-location-label">
                   <label className="flex items-center">
                     <input
                       type="radio"
@@ -343,6 +352,7 @@ export function InitialQuestions({ onComplete }: InitialQuestionsProps) {
                     <Input
                       id="contentUrl"
                       type="text"
+                      aria-label="URL where the content can be found"
                       {...register('contentUrl', {
                         required: 'Please provide the URL where the content can be found',
                         validate: {
@@ -370,6 +380,7 @@ export function InitialQuestions({ onComplete }: InitialQuestionsProps) {
                       <div className="flex-1">
                         <Textarea
                           id="contentDescription"
+                          aria-label="Describe where the content can be found"
                           {...register('contentDescription', {
                             required: 'Please describe where the content can be found',
                           })}

--- a/app/letter-generator/components/letter-review.tsx
+++ b/app/letter-generator/components/letter-review.tsx
@@ -305,17 +305,17 @@ export function LetterReview({
 
           <div className="space-y-4">
             <div>
-              <h4 className="text-lg font-medium mb-2">Send email to</h4>
+              <h3 className="text-lg font-medium mb-2">Send email to</h3>
               <div className="p-4 bg-white rounded-lg">{platformEmail}</div>
             </div>
 
             <div>
-              <h4 className="text-lg font-medium mb-2">Subject line</h4>
+              <h3 className="text-lg font-medium mb-2">Subject line</h3>
               <div className="p-4 bg-white rounded-lg select-none">{displayLetter.subject}</div>
             </div>
 
             <div>
-              <h4 className="text-lg font-medium mb-2">Message content</h4>
+              <h3 className="text-lg font-medium mb-2">Message content</h3>
               <div className="p-4 bg-white rounded-lg whitespace-pre-wrap select-none">
                 {displayLetter.body}
               </div>
@@ -326,7 +326,7 @@ export function LetterReview({
             <div className="flex flex-col gap-4">
               <div className="flex items-center justify-between">
                 <div className="flex-1">
-                  <h4 className="text-base mb-1">Copy your letter</h4>
+                  <h3 className="text-base mb-1">Copy your letter</h3>
                   <p className="text-sm text-muted-foreground">
                     Copy and paste your letter into an email. Before sending, add your name at the
                     end of the letter and ensure the subject line is included.
@@ -359,7 +359,7 @@ export function LetterReview({
                   {!feedbackSubmitted ? (
                     <>
                       <div>
-                        <h4 className="text-base mb-1">Is this useful?</h4>
+                        <h3 className="text-base mb-1">Is this useful?</h3>
                         <p className="text-sm text-muted-foreground">
                           Did this tool produce a letter that you think could be useful for your
                           case?
@@ -409,7 +409,7 @@ export function LetterReview({
                     </>
                   ) : (
                     <div className="flex flex-col gap-2">
-                      <h4 className="text-base font-medium">Your feedback has been submitted</h4>
+                      <h3 className="text-base font-medium">Your feedback has been submitted</h3>
                       <p className="text-sm text-muted-foreground">
                         Thank you for your feedback. This tool is new and learning! By sharing your
                         experience, you help us make this tool more supportive for others in similar
@@ -431,7 +431,7 @@ export function LetterReview({
               <div className="p-6 bg-white rounded-lg">
                 <div className="flex flex-col gap-4">
                   <div>
-                    <h4 className="text-base mb-1">Not quite right?</h4>
+                    <h3 className="text-base mb-1">Not quite right?</h3>
                     <p className="text-sm text-muted-foreground">
                       Sometimes our AI doesn&apos;t get it quite right. You can try regenerating a
                       different letter using the same information to see if you prefer it.

--- a/app/letter-generator/components/platform-selection.tsx
+++ b/app/letter-generator/components/platform-selection.tsx
@@ -153,12 +153,12 @@ export function PlatformSelection({ onComplete }: PlatformSelectionProps) {
               <div className="w-8 h-8 mb-2 relative">
                 <Image
                   src={platform.logo}
-                  alt={`${platform.name} logo`}
+                  alt=""
                   fill
                   className={`object-contain ${platform.id === 'pornhub' ? 'rounded-sm' : ''}`}
                 />
               </div>
-              <h3 className="text-sm font-medium">{platform.name}</h3>
+              <span className="text-sm font-medium">{platform.name}</span>
             </div>
           </RadioGroupPrimitive.Item>
         ))}
@@ -173,10 +173,10 @@ export function PlatformSelection({ onComplete }: PlatformSelectionProps) {
           <div className="flex flex-col items-center text-center">
             <div className="w-8 h-8 mb-2 flex items-center justify-center">
               <div className="w-6 h-6 rounded-full bg-muted flex items-center justify-center">
-                <span className="text-base">+</span>
+                <span aria-hidden="true" className="text-base">+</span>
               </div>
             </div>
-            <h3 className="text-sm font-medium">Other platform</h3>
+            <span className="text-sm font-medium">Other platform</span>
           </div>
         </RadioGroupPrimitive.Item>
       </RadioGroupPrimitive.Root>

--- a/app/letter-generator/components/platform-selection.tsx
+++ b/app/letter-generator/components/platform-selection.tsx
@@ -138,11 +138,17 @@ export function PlatformSelection({ onComplete }: PlatformSelectionProps) {
           <RadioGroupPrimitive.Item
             key={platform.id}
             value={platform.id}
-            className={`cursor-pointer p-3 rounded-xl transition-transform
+            className={`relative cursor-pointer p-3 rounded-xl transition-transform
             hover:scale-[1.02] active:scale-[0.98]
             focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
             ${selectedPlatform === platform.id ? 'bg-accent-light border border-accent' : 'bg-white'}`}
           >
+            <span
+              aria-hidden="true"
+              className="absolute top-2 right-2 flex h-4 w-4 items-center justify-center rounded-full border border-muted-foreground/50 bg-white"
+            >
+              <RadioGroupPrimitive.Indicator className="h-2 w-2 rounded-full bg-accent" />
+            </span>
             <div className="flex flex-col items-center text-center">
               <div className="w-8 h-8 mb-2 relative">
                 <Image

--- a/app/letter-generator/components/platform-selection.tsx
+++ b/app/letter-generator/components/platform-selection.tsx
@@ -14,6 +14,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { AlertTriangle, Loader2 } from 'lucide-react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 
 interface PlatformSelectionProps {
   onComplete: (platformInfo: PlatformInfo) => void;
@@ -127,17 +128,20 @@ export function PlatformSelection({ onComplete }: PlatformSelectionProps) {
 
   return (
     <div className="space-y-8">
-      <div className="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+      <RadioGroupPrimitive.Root
+        value={selectedPlatform}
+        onValueChange={(value) => setSelectedPlatform(value as PlatformId | 'other')}
+        aria-label="Select the platform where the content is hosted"
+        className="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4"
+      >
         {platforms.map((platform) => (
-          <motion.div
+          <RadioGroupPrimitive.Item
             key={platform.id}
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-            className={`
-              cursor-pointer p-3 rounded-xl transition-colors
-              ${selectedPlatform === platform.id ? 'bg-accent-light border border-accent' : 'bg-white'}
-            `}
-            onClick={() => setSelectedPlatform(platform.id)}
+            value={platform.id}
+            className={`cursor-pointer p-3 rounded-xl transition-transform
+            hover:scale-[1.02] active:scale-[0.98]
+            focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
+            ${selectedPlatform === platform.id ? 'bg-accent-light border border-accent' : 'bg-white'}`}
           >
             <div className="flex flex-col items-center text-center">
               <div className="w-8 h-8 mb-2 relative">
@@ -150,17 +154,15 @@ export function PlatformSelection({ onComplete }: PlatformSelectionProps) {
               </div>
               <h3 className="text-sm font-medium">{platform.name}</h3>
             </div>
-          </motion.div>
+          </RadioGroupPrimitive.Item>
         ))}
 
-        <motion.div
-          whileHover={{ scale: 1.02 }}
-          whileTap={{ scale: 0.98 }}
-          className={`
-            cursor-pointer p-3 rounded-xl transition-colors
-            ${selectedPlatform === 'other' ? 'bg-accent-light border border-accent' : 'bg-white'}
-          `}
-          onClick={() => setSelectedPlatform('other')}
+        <RadioGroupPrimitive.Item
+          value="other"
+          className={`cursor-pointer p-3 rounded-xl transition-transform
+              hover:scale-[1.02] active:scale-[0.98]
+              focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
+              ${selectedPlatform === 'other' ? 'bg-accent-light border border-accent' : 'bg-white'}`}
         >
           <div className="flex flex-col items-center text-center">
             <div className="w-8 h-8 mb-2 flex items-center justify-center">
@@ -170,8 +172,8 @@ export function PlatformSelection({ onComplete }: PlatformSelectionProps) {
             </div>
             <h3 className="text-sm font-medium">Other platform</h3>
           </div>
-        </motion.div>
-      </div>
+        </RadioGroupPrimitive.Item>
+      </RadioGroupPrimitive.Root>
 
       {selectedPlatform === 'other' && (
         <motion.div
@@ -208,10 +210,10 @@ export function PlatformSelection({ onComplete }: PlatformSelectionProps) {
                     <h4 className="font-medium">Reminder about messaging platforms</h4>
                     <p className="text-muted-foreground text-sm">
                       Remember that for messaging platforms such as WhatsApp, iMessage, Signal and
-                      Telegram, the platform does not have the power to remove content from people&apos;s
-                      messaging threads or groups. If you have been sent the content, or are in the
-                      group it was shared then you can report the individual sharing it from within
-                      the app.
+                      Telegram, the platform does not have the power to remove content from
+                      people&apos;s messaging threads or groups. If you have been sent the content,
+                      or are in the group it was shared then you can report the individual sharing
+                      it from within the app.
                     </p>
                     <p className="text-muted-foreground text-sm">
                       You can still go ahead and generate a letter to send to the platform if you

--- a/app/letter-generator/components/process-explanation.tsx
+++ b/app/letter-generator/components/process-explanation.tsx
@@ -100,11 +100,11 @@ export function ProcessExplanation({ onComplete }: { onComplete: () => void }) {
                       className: `w-5 h-5 ${isClickable ? 'text-accent' : 'text-accent/80'}`,
                     })}
                   </div>
-                  <h3
+                  <h2
                     className={`font-medium ${isClickable ? 'text-foreground' : 'text-muted-foreground'}`}
                   >
                     {step.title}
-                  </h3>
+                  </h2>
                 </div>
 
                 <div className="space-y-2">
@@ -126,7 +126,7 @@ export function ProcessExplanation({ onComplete }: { onComplete: () => void }) {
             <Lock className="w-5 h-5 text-accent" />
           </div>
           <div className="flex-1 text-left">
-            <h3 className="text-base font-medium">Your privacy and data protection</h3>
+            <h2 className="text-base font-medium">Your privacy and data protection</h2>
             <p className="text-sm text-muted-foreground">
               Learn how we protect your information and use AI responsibly
             </p>

--- a/app/letter-generator/components/progress-bar.tsx
+++ b/app/letter-generator/components/progress-bar.tsx
@@ -21,19 +21,29 @@ const stepNames = [
 export function ProgressBar({ currentStep, totalSteps }: ProgressBarProps) {
   const progress = (currentStep / totalSteps) * 100;
   const [hoveredStep, setHoveredStep] = useState<number | null>(null);
+  const visibleSteps = stepNames.slice(0, totalSteps);
+  const hasCurrent = currentStep >= 1 && currentStep <= visibleSteps.length;
 
   return (
     <div className="w-full max-w-[800px] m-auto my-4 mb-6">
-      <div className="relative flex items-center justify-between">
-        <div className="absolute left-0 right-0 h-1 bg-muted/50" />
+      {/* Announce the current step to screen readers as the user advances */}
+      <p className="sr-only" aria-live="polite">
+        {hasCurrent
+          ? `Step ${currentStep} of ${visibleSteps.length}: ${stepNames[currentStep - 1]}`
+          : ''}
+      </p>
+
+      <div role="list" aria-label="Progress" className="relative flex items-center justify-between">
+        <div aria-hidden="true" className="absolute left-0 right-0 h-1 bg-muted/50" />
         <motion.div
+          aria-hidden="true"
           className="absolute left-0 h-1 bg-accent origin-left"
           initial={{ width: 0 }}
           animate={{ width: `${progress}%` }}
           transition={{ duration: 0.5 }}
         />
 
-        {stepNames.slice(0, totalSteps).map((name, index) => {
+        {visibleSteps.map((name, index) => {
           const stepNumber = index;
           const isCurrent = stepNumber === currentStep - 1;
           const isPast = stepNumber < currentStep;
@@ -41,11 +51,17 @@ export function ProgressBar({ currentStep, totalSteps }: ProgressBarProps) {
           return (
             <div
               key={index}
+              role="listitem"
+              aria-current={isCurrent ? 'step' : undefined}
               className="relative z-10"
               onMouseEnter={() => setHoveredStep(stepNumber)}
               onMouseLeave={() => setHoveredStep(null)}
             >
+              <span className="sr-only">
+                {name} — {isCurrent ? 'current step' : isPast ? 'completed' : 'not started'}
+              </span>
               <motion.div
+                aria-hidden="true"
                 className={`
                   w-3 h-3 rounded-full transition-all duration-200
                   ${
@@ -63,6 +79,7 @@ export function ProgressBar({ currentStep, totalSteps }: ProgressBarProps) {
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
                   className="absolute left-1/2 -translate-x-1/2 mt-2"
+                  aria-hidden="true"
                 >
                   <div
                     className={`

--- a/app/letter-generator/components/question-section.tsx
+++ b/app/letter-generator/components/question-section.tsx
@@ -14,7 +14,7 @@ export function QuestionSection({ title, children }: QuestionSectionProps) {
       animate={{ opacity: 1, y: 0 }}
       className="space-y-6"
     >
-      {title && <h2 className="text-xl font-medium mb-6">{title}</h2>}
+      {title && <h3 className="text-xl font-medium mb-6">{title}</h3>}
       {children && <div className="space-y-8">{children}</div>}
     </motion.div>
   );

--- a/app/letter-generator/components/removal-process.tsx
+++ b/app/letter-generator/components/removal-process.tsx
@@ -92,7 +92,7 @@ export function RemovalProcess({ onComplete }: RemovalProcessProps) {
   return (
     <div className="space-y-6">
       <div className="bg-white rounded-xl p-6">
-        <h2 className="text-xl font-medium mb-2">Available reporting processes</h2>
+        <h3 className="text-xl font-medium mb-2">Available reporting processes</h3>
         <p className="text-muted-foreground mb-4">
           Below are the standard and escalated reporting processes for content removal on{' '}
           {platformName}.
@@ -104,7 +104,7 @@ export function RemovalProcess({ onComplete }: RemovalProcessProps) {
               <CollapsibleTrigger className="w-full text-left px-4 py-3">
                 <div className="flex items-center justify-between">
                   <div>
-                    <h3 className="text-base font-medium">Standard reporting process</h3>
+                    <h4 className="text-base font-medium">Standard reporting process</h4>
                     <p className="text-sm text-muted-foreground">
                       The platform&apos;s built-in reporting system for content removal
                     </p>
@@ -133,7 +133,7 @@ export function RemovalProcess({ onComplete }: RemovalProcessProps) {
               <CollapsibleTrigger className="w-full text-left px-4 py-3">
                 <div className="flex items-center justify-between">
                   <div>
-                    <h3 className="text-base font-medium">Escalated reporting process</h3>
+                    <h4 className="text-base font-medium">Escalated reporting process</h4>
                     <p className="text-sm text-muted-foreground">
                       Additional support channels for sensitive content removal requests
                     </p>
@@ -160,12 +160,13 @@ export function RemovalProcess({ onComplete }: RemovalProcessProps) {
 
         <div className="mt-8 space-y-6">
           <div className="space-y-4">
-            <h4 className="text-lg font-medium">
+            <h3 id="reporting-status-label" className="text-lg font-medium">
               Have you previously tried any of these processes?
-            </h4>
+            </h3>
             <RadioGroup
               value={status || ''}
               onValueChange={(value) => handleStatusChange(value as ReportingStatus)}
+              aria-labelledby="reporting-status-label"
               className="space-y-3"
             >
               <div className="flex items-center space-x-3">

--- a/app/letter-generator/components/selectable-card.tsx
+++ b/app/letter-generator/components/selectable-card.tsx
@@ -1,38 +1,39 @@
 'use client';
 
 import { cn } from '@/lib/utils';
-import { motion } from 'framer-motion';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 
 interface SelectableCardProps {
   value: string;
   label: string;
   description?: string;
-  selected: boolean;
-  onClick: () => void;
 }
 
-export function SelectableCard({
-  label,
-  description,
-  selected,
-  onClick,
-}: SelectableCardProps) {
+export function SelectableCard({ value, label, description }: SelectableCardProps) {
   return (
-    <motion.div
-      whileHover={{ scale: 1.02 }}
-      whileTap={{ scale: 0.98 }}
-      onClick={onClick}
+    <RadioGroupPrimitive.Item
+      value={value}
       className={cn(
-        'relative cursor-pointer rounded-lg p-3.5 transition-all duration-200',
-        selected ? 'bg-accent-light border-accent shadow-md' : 'bg-white hover:bg-neutral/10',
+        'relative cursor-pointer rounded-lg p-3.5 text-left transition-all duration-200',
+        'border border-transparent bg-white hover:bg-neutral/10',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2',
+        'data-[state=checked]:border-accent data-[state=checked]:bg-accent-light data-[state=checked]:shadow-md',
       )}
     >
-      <div className="space-y-1">
-        <h4 className="text-sm font-medium text-foreground">{label}</h4>
+      <span
+        aria-hidden="true"
+        className="absolute top-3 right-3 flex h-4 w-4 items-center justify-center rounded-full border border-muted-foreground/50 bg-white"
+      >
+        <RadioGroupPrimitive.Indicator className="h-2 w-2 rounded-full bg-accent" />
+      </span>
+      <span className="block space-y-1 pr-7">
+        <span className="block text-sm font-medium text-foreground">{label}</span>
         {description && (
-          <p className="text-sm text-muted-foreground/90 leading-relaxed">{description}</p>
+          <span className="block text-sm text-muted-foreground/90 leading-relaxed">
+            {description}
+          </span>
         )}
-      </div>
-    </motion.div>
+      </span>
+    </RadioGroupPrimitive.Item>
   );
 }

--- a/app/letter-generator/components/voice-input.tsx
+++ b/app/letter-generator/components/voice-input.tsx
@@ -51,6 +51,8 @@ export function VoiceInput({ isListening, onToggle, className }: VoiceInputProps
         type="button"
         variant="ghost"
         size="icon"
+        aria-label={isListening ? 'Stop voice input' : 'Start voice input'}
+        aria-pressed={isListening}
         className={cn(
           "relative h-10 w-10 rounded-full transition-all duration-200",
           isListening 

--- a/app/letter-generator/page.tsx
+++ b/app/letter-generator/page.tsx
@@ -321,9 +321,9 @@ export default function LetterGenerator() {
                     onRetry={handleRetryGeneration}
                   />
                 ) : (
-                  <div className="flex flex-col items-center justify-center py-8 sm:py-12">
+                  <div role="status" className="flex flex-col items-center justify-center py-8 sm:py-12">
                     <div className="bg-accent-light/50 rounded-xl p-6 max-w-xl text-center">
-                      <Loader2 className="w-8 h-8 mx-auto mb-4 animate-spin text-primary" />
+                      <Loader2 className="w-8 h-8 mx-auto mb-4 animate-spin text-primary" aria-hidden="true" />
                       <h3 className="text-lg font-medium mb-2">
                         {isRegenerating ? 'Regenerating your letter' : 'Creating your letter'}
                       </h3>

--- a/app/letter-generator/page.tsx
+++ b/app/letter-generator/page.tsx
@@ -32,6 +32,8 @@ type Step =
   | 'generation'
   | 'review';
 
+const PAGE_TITLE = 'Building your takedown letter';
+
 const stepTitles: Record<Step, string> = {
   'process-explanation': 'Building your takedown letter',
   'platform-selection': 'Select the platform',
@@ -225,6 +227,11 @@ export default function LetterGenerator() {
     ? formState.platformInfo.customName
     : formState.platformInfo?.platformName || 'Unknown Platform';
 
+  // The page always has exactly one h1 = PAGE_TITLE. On the overview step the
+  // visible title already is PAGE_TITLE, so it serves as the h1; on every other
+  // step we add a visually-hidden h1 and drop the visible step title to an h2.
+  const titleIsPageTitle = stepTitles[currentStep] === PAGE_TITLE;
+
   return (
     <main className="flex-1">
       <div className="max-w-5xl mx-auto py-2">
@@ -258,8 +265,13 @@ export default function LetterGenerator() {
               </Button>
             )}
 
+            {!titleIsPageTitle && <h1 className="sr-only">{PAGE_TITLE}</h1>}
             <div className="flex flex-col items-start">
-              <h2 className="text-2xl sm:text-3xl mb-4">{stepTitles[currentStep]}</h2>
+              {titleIsPageTitle ? (
+                <h1 className="text-2xl sm:text-3xl mb-4">{stepTitles[currentStep]}</h1>
+              ) : (
+                <h2 className="text-2xl sm:text-3xl mb-4">{stepTitles[currentStep]}</h2>
+              )}
               <p className="text-muted-foreground">{stepDescriptions[currentStep]} </p>
             </div>
 

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -25,7 +25,7 @@ export function Footer() {
             </p>
           </div>
           <div>
-            <h3 className="font-merriweather text-lg mb-4">About Chayn&apos;s Survivor AI</h3>
+            <h2 className="font-merriweather text-lg mb-4">About Chayn&apos;s Survivor AI</h2>
             <p className="text-muted-foreground max-w-md text-sm md:text-[15px]">
               Our Survivor AI was created by Chayn to empower those affected by image-based abuse. We provide 
               compassionate guidance through the takedown request process, using AI to help you create 

--- a/cypress/e2e/data-collection.cy.ts
+++ b/cypress/e2e/data-collection.cy.ts
@@ -13,11 +13,11 @@ describe('Development Data Collection', () => {
 
     // Complete a full flow
     cy.contains('Start your request').click();
-    cy.get('h2').contains('Building your takedown letter');
+    cy.contains('Building your takedown letter');
     cy.contains('Start your request').click();
 
     // Platform selection
-    cy.get('h3').contains('Instagram').click();
+    cy.contains('[role="radio"]', 'Instagram').click();
     cy.contains('Continue').click();
 
     // Reporting status
@@ -69,7 +69,7 @@ describe('Development Data Collection', () => {
 
     // Complete minimal flow
     cy.contains('Start your request').click();
-    cy.get('h2').contains('Building your takedown letter');
+    cy.contains('Building your takedown letter');
     cy.contains('Start your request').click();
     cy.contains('Other platform').click();
     cy.get('#other-platform').type('TestPlatform');

--- a/cypress/e2e/platforms.cy.ts
+++ b/cypress/e2e/platforms.cy.ts
@@ -132,7 +132,7 @@ describe('Platform Tests', () => {
     cy.visit('/');
     cy.dismissDevWarning();
     cy.contains('Start your request').click();
-    cy.get('h2').contains('Building your takedown letter');
+    cy.contains('Building your takedown letter');
     cy.contains('Start your request', { timeout: 10000 }).click();
   }
 
@@ -141,7 +141,7 @@ describe('Platform Tests', () => {
       cy.contains('Other platform').click();
       cy.get('#other-platform').type(platformName);
     } else {
-      cy.get('h3').contains(platformName).click();
+      cy.contains('[role="radio"]', platformName).click();
     }
     cy.contains('Continue').click();
   }

--- a/cypress/e2e/sanitization.cy.ts
+++ b/cypress/e2e/sanitization.cy.ts
@@ -76,7 +76,7 @@ describe('Content Location Sanitization and Desanitization', () => {
 
   function startFlow() {
     cy.contains('Start your request').click();
-    cy.get('h2').contains('Building your takedown letter', { timeout: 10000 });
+    cy.contains('Building your takedown letter', { timeout: 10000 });
     cy.contains('Start your request').click();
   }
 
@@ -85,7 +85,7 @@ describe('Content Location Sanitization and Desanitization', () => {
       cy.contains('Other platform').click();
       cy.get('#other-platform').type('Reddit');
     } else {
-      cy.get('h3').contains(platformName).click();
+      cy.contains('[role="radio"]', platformName).click();
     }
     cy.contains('Continue').click();
   }
@@ -124,14 +124,13 @@ describe('Content Location Sanitization and Desanitization', () => {
   function waitForLetterGeneration() {
     cy.contains('Continue', { timeout: 30000 }).click();
     cy.contains('Review and send', { timeout: 100000 }).should('be.visible');
-    cy.get('h4').contains('Message content', { timeout: 10000 }).should('be.visible');
+    cy.contains('Message content', { timeout: 10000 }).should('be.visible');
   }
 
   function verifyContentLocationInLetter(
     expectedLocation: string,
   ) {
-    cy.get('h4')
-      .contains('Message content')
+    cy.contains('Message content')
       .parent()
       .within(() => {
         cy.get('div').should('contain', expectedLocation);
@@ -213,8 +212,7 @@ describe('Content Location Sanitization and Desanitization', () => {
     verifyContentLocationInLetter(sensitiveData.contentLocation);
 
     // Verify that other sensitive data has been properly sanitized and restored
-    cy.get('h4')
-      .contains('Message content')
+    cy.contains('Message content')
       .parent()
       .within(() => {
         // Should contain the original sensitive data (properly desanitized)

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -64,8 +64,7 @@ Cypress.Commands.add('verifyDevWarningContent', () => {
 
 Cypress.Commands.add('verifyContentLocationInLetter', (expectedLocation: string) => {
   // Verify the content location appears in the letter body
-  cy.get('h4')
-    .contains('Message content')
+  cy.contains('Message content')
     .parent()
     .within(() => {
       cy.get('div').should('contain', expectedLocation);
@@ -82,7 +81,7 @@ Cypress.Commands.add(
   (platform: string, contentLocation: string, locationType: 'url' | 'description') => {
     // Start the process
     cy.contains('Start your request').click();
-    cy.get('h2').contains('Building your takedown letter');
+    cy.contains('Building your takedown letter');
     cy.contains('Start your request').click();
 
     // Select platform
@@ -90,7 +89,7 @@ Cypress.Commands.add(
       cy.contains('Other platform').click();
       cy.get('#other-platform').type('TestPlatform');
     } else {
-      cy.get('h3').contains(platform).click();
+      cy.contains('[role="radio"]', platform).click();
     }
     cy.contains('Continue').click();
 


### PR DESCRIPTION
### Resolves #499 

### What changes did you make and why did you make them?

- Made the entire https://tools.chayn.co/letter-generator flow keyboard and screen-reader accessible. Verified with keyboard navigation, the browser accessibility tree, and HeadingsMap.
- Updated the selection cards: From clickable `<div>`s to Radix radio groups (keyboard-selectable, focus ring, radio-dot)
- One `<h1>` per step + fixed heading-level skips
- Voice-input mic buttons: added accessible name + `aria-pressed`
- Loading/error states announced via `role="status"` / `role="alert"`
- Updated Cypress selectors for the new DOM
- Progress stepper: exposed to screen readers as a labeled list with per-step status + `aria-current`, plus a live "Step X of Y" announcement

#### Video walkthrough of why I made this change
The user isn't able to select a platform using accessibility tools/keyboard which means they can't submit a request.

#### Before
https://github.com/user-attachments/assets/a195d35f-d939-4fd7-b32f-44361fc1b4aa

#### After
https://github.com/user-attachments/assets/2a843a75-2bc3-446a-8985-63cbb564c5b7

#### Heading-level Corrected

| Before | After | 
| --- | --- |
| <img width="1776" height="920" alt="Screenshot 2026-06-19 at 11 41 11 PM" src="https://github.com/user-attachments/assets/3f5dca48-d01f-44cb-9cea-68ac9309eb12" /> | <img width="1778" height="912" alt="Screenshot 2026-06-19 at 11 42 12 PM" src="https://github.com/user-attachments/assets/d3785f46-7be5-4ceb-9025-46046ea35473" /> |
| <img width="1778" height="916" alt="Screenshot 2026-06-19 at 11 43 08 PM" src="https://github.com/user-attachments/assets/7772ff1c-f517-4545-99f7-9db3a505d80a" /> | <img width="1776" height="918" alt="Screenshot 2026-06-19 at 11 43 44 PM" src="https://github.com/user-attachments/assets/32f36bc7-7145-4bc0-bf1d-8188465900e9" /> |
| <img width="1775" height="921" alt="Screenshot 2026-06-19 at 11 44 30 PM" src="https://github.com/user-attachments/assets/eb10df7a-ca8c-46e0-be88-87ee8b4b7c21" /> | <img width="1776" height="918" alt="Screenshot 2026-06-19 at 11 45 07 PM" src="https://github.com/user-attachments/assets/f27af368-1cb5-45be-a7bf-987b78f7dba7" /> |

#### Screen-reader announcements

| Radio group |
| --- | 
| <img width="1769" height="921" alt="Screenshot 2026-06-19 at 11 56 29 PM" src="https://github.com/user-attachments/assets/741adfe5-4bfa-47f7-9435-dbcfcb9e6be3" /> |

| Progress bar |
| --- | 
| <img width="1771" height="985" alt="Screenshot 2026-06-19 at 11 57 54 PM" src="https://github.com/user-attachments/assets/33340f85-fe8a-4e01-8b7a-814ee93855b7" /> |


### Did you run tests? Please share screenshots:

- npx eslint → passes (0 errors)
- npm run type-check → passes
- The E2E suite is configured to run in CI against the deployed preview. It currently does not run successfully in my local environment, and the failure is unrelated to the changes in this PR.

<img width="604" height="137" alt="Screenshot 2026-06-19 at 11 38 35 PM" src="https://github.com/user-attachments/assets/723ba677-d1c5-41d7-9afa-ff8cf123b805" />

<img width="1043" height="394" alt="Screenshot 2026-06-19 at 11 40 00 PM" src="https://github.com/user-attachments/assets/61a2c359-71b2-43ac-b169-b297c4ff66d1" />


### How did you find us? (GitHub, Google search, social media, hackathon, etc.):

Social Media

<!--- PR CHECKLIST: —>
Before submitting, check that you have completed the following tasks:
- [x] Answered the questions above.
- [x] Enabled "Allow edits and access to secrets by maintainers" on this PR.
- [x] If applicable, include images in the description.
After submitting, please be available for discussion. Thank you!
