### PR TITLE
Fix policy validation streaming

### DIFF
--- a/lib/ai/anthropic.ts
+++ b/lib/ai/anthropic.ts
@@ -3,15 +3,20 @@ import { MessageCreateParamsNonStreaming } from '@anthropic-ai/sdk/resources/mes
 import { serverInstance as rollbar } from '../rollbar';
 import { retryWithDelay } from '../utils';
 
-// Initialize Anthropic client with an explicit per-request timeout. Without
-// one, the SDK's default timeout is long and a stalled/rate-limited request can
-// hang the policy-validation step for the full job budget. The abstraction step
-// fires one call per document in parallel with no concurrency cap, so a burst
-// on a large platform (facebook/instagram/tiktok) can trigger 429s; bound each
-// call so it fails fast and surfaces a real error instead of hanging.
+// The document-validation call uses the web_search server tool (up to 10
+// searches), which is a long, tool-heavy request. Anthropic's guidance is to
+// STREAM such requests (see callAnthropic below) so they don't hit the HTTP
+// request timeout — callAnthropic uses `.stream().finalMessage()` for exactly
+// this reason. A short non-streaming timeout is the wrong tool here: the SDK
+// retries timeouts (wall-clock = timeout x (maxRetries+1)) and our own
+// retryWithDelay wraps that again, so a slow call thrashes for many minutes
+// instead of completing. Keep maxRetries low to avoid multiplying retries, and
+// a generous timeout as a last-resort backstop (the 30-min job cap is the outer
+// bound). This is what made facebook/instagram/tiktok hang while the smaller
+// onlyfans/pornhub policies completed inside the old timeout.
 const anthropic = new Anthropic({
-  timeout: 2 * 60 * 1000, // 2 minutes per request
-  maxRetries: 2,
+  timeout: 10 * 60 * 1000, // 10 minutes; streaming keeps the connection alive
+  maxRetries: 1,
 });
 
 export async function callAnthropic(
@@ -24,29 +29,37 @@ export async function callAnthropic(
   }
 
   return await retryWithDelay(async () => {
-    const response = await anthropic.messages.create({
-      model: process.env.ANTHROPIC_MODEL || 'claude-sonnet-5',
-      // Sonnet 5's tokenizer produces ~30% more tokens than Sonnet 4.6 for the
-      // same text, so a limit tuned for the old model can now truncate output
-      // mid-JSON (→ `stop_reason: "max_tokens"` → parseAIJson fails). Thinking is
-      // disabled below, so nothing competes with output for this budget. Callers
-      // needing more headroom can override `max_tokens` via `config`.
-      max_tokens: 16000,
-      // Claude Sonnet 5 runs adaptive thinking by default when `thinking` is
-      // omitted. We disable it explicitly to keep latency and cost predictable,
-      // and because forced `tool_choice` (used by the structured-JSON routes) is
-      // only reliable with thinking disabled. Callers can opt into reasoning by
-      // passing `thinking` (and optionally `output_config.effort`) in `config`.
-      thinking: { type: 'disabled' },
-      messages: [
-        {
-          role: 'user',
-          content: prompt,
-        },
-      ],
-      ...config,
-    });
-    
+    // Stream the request and collect the final message. Streaming is required
+    // for long / tool-heavy / high-max_tokens requests (e.g. the web_search
+    // document-validation call) — a non-streaming request holds one HTTP
+    // connection open for the whole server-side tool loop and trips the request
+    // timeout on large platforms. `.finalMessage()` returns the same complete
+    // Message shape as `.create()`, so the parsing below is unchanged.
+    const response = await anthropic.messages
+      .stream({
+        model: process.env.ANTHROPIC_MODEL || 'claude-sonnet-5',
+        // Sonnet 5's tokenizer produces ~30% more tokens than Sonnet 4.6 for the
+        // same text, so a limit tuned for the old model can now truncate output
+        // mid-JSON (→ `stop_reason: "max_tokens"` → parseAIJson fails). Thinking is
+        // disabled below, so nothing competes with output for this budget. Callers
+        // needing more headroom can override `max_tokens` via `config`.
+        max_tokens: 16000,
+        // Claude Sonnet 5 runs adaptive thinking by default when `thinking` is
+        // omitted. We disable it explicitly to keep latency and cost predictable,
+        // and because forced `tool_choice` (used by the structured-JSON routes) is
+        // only reliable with thinking disabled. Callers can opt into reasoning by
+        // passing `thinking` (and optionally `output_config.effort`) in `config`.
+        thinking: { type: 'disabled' },
+        messages: [
+          {
+            role: 'user',
+            content: prompt,
+          },
+        ],
+        ...config,
+      })
+      .finalMessage();
+
     if(config.tool_choice?.type === 'tool' && config.tool_choice.name === 'json') {
       const toolCall = response.content.find(block => block.type === 'tool_use');
 


### PR DESCRIPTION
Fixes streaming of web calls on policy validation flow, which was previously timing out