### PR TITLE
Make policy validation Step 1 reliable: classic web_search + always run real comparison

### DIFF
--- a/lib/ai/policy-validation/documents-validator.ts
+++ b/lib/ai/policy-validation/documents-validator.ts
@@ -22,7 +22,16 @@ export async function validateDocuments(
     const response = await callAnthropic(prompt, {
       tools: [
         {
-          type: 'web_search_20260209',
+          // Use the classic, non-agentic web_search version. `web_search_20260209`
+          // runs a server-side *code-execution* loop (dynamic filtering) on every
+          // use — "33s–2min, highly variable" per use — which at max_uses:10
+          // compounded into ~13 min on large platforms and often returned degraded
+          // results, causing the model to rubber-stamp everything `valid` (→ runs
+          // that hung on Step 1 then reported "no changes"). The classic version
+          // returns results directly with no code-exec step (~2–3s per search), so
+          // we keep max_uses high for thorough discovery and the speed-up comes
+          // from dropping the agentic filtering, not from searching less.
+          type: 'web_search_20250305',
           name: 'web_search',
           max_uses: 10,
         },

--- a/lib/ai/policy-validation/orchestrator.ts
+++ b/lib/ai/policy-validation/orchestrator.ts
@@ -66,27 +66,17 @@ export async function orchestratePolicyValidation(
       })),
     );
 
-    if (
-      documentValidation.status === 'valid' &&
-      documentValidation.newDocuments.length === 0 &&
-      documentValidation.removedDocuments.length === 0 &&
-      documentValidation.validDocuments.every((doc) => doc.status === 'valid')
-    ) {
-      return {
-        status: 'completed_no_changes',
-        platformId,
-        platformName,
-        data: {
-          documentValidation,
-          analysis: {
-            reasoning:
-              'Document validation found no changes needed. All documents are current and accessible.',
-          },
-        },
-        reasoning:
-          'Document validation found no changes needed. All documents are current and accessible.',
-      };
-    }
+    // We intentionally do NOT short-circuit to "no changes" based on the
+    // document-validation verdict. That verdict comes from an LLM + web_search
+    // call which is variable and, when the search underperforms, rubber-stamps
+    // every document as `valid` — silently skipping the real work and reporting
+    // "no changes" even when the policies have changed (the root cause of runs
+    // that appeared to hang on Step 1 and then returned "no changes needed").
+    // Change detection is done authoritatively in Step 5 by scraping each
+    // document and comparing its actual content (comparePlatformPolicies), so we
+    // always run the full pipeline. Step 1's role is limited to discovering
+    // new/removed documents; whether the known documents changed is decided by
+    // the real content comparison, not by the search verdict.
 
     // Step 2: Scrape updated/new documents
 


### PR DESCRIPTION

Two root causes behind runs that hung on 'Step 1: validating current documents' and then reported 'no changes needed':

1. Step 1 used the AGENTIC web_search_20260209 (max_uses: 10), which runs a server-side code-execution/dynamic-filtering loop per use — highly variable, ~13 min on large platforms. Switch to the classic web_search_20250305 (~2-3s per search, no code-exec step); keep max_uses: 10 for thorough discovery. The latency came from the agentic version, not the search count.

2. The orchestrator short-circuited to completed_no_changes based on Step 1's LLM+web_search verdict. When the search underperformed, the model rubber-stamped every document 'valid', so the pipeline skipped the real work and reported 'no changes' even when policies had changed. Remove the short-circuit: always scrape + abstract + compare. Change detection is done authoritatively in Step 5 (comparePlatformPolicies) on real document content; Step 1 is now only for discovering new/removed documents.


